### PR TITLE
Tornar `stow --adopt` opt-in, mover Obsidian para Homebrew e endurecer proteção

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -2,6 +2,12 @@
 
 #TODO Testar se o arquivo ~/.zshrc existe e criar ele caso não exista e adicionar o comando ao final do arquivo `eval "$(starship init zsh)"`
 echo "Iniciando configuração dos pacotes de configuração usando o comando \"stow\""
-stow . --adopt -v
+if [[ "${STOW_ADOPT:-0}" == "1" ]]; then
+  echo "Modo --adopt habilitado (STOW_ADOPT=1)."
+  stow . --adopt -v
+else
+  echo "Modo --adopt desabilitado. Defina STOW_ADOPT=1 para habilitar."
+  stow . -v
+fi
 
 zsh/zsh-config.sh

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -13,7 +13,7 @@
   let
     commonConfiguration = { pkgs, ... }: {
       system.primaryUser = "adrianofsantos";
-      nixpkgs.config.allowUnfree = true;
+      nixpkgs.config.allowUnfree = false;
       # Fonts
       fonts.packages = with pkgs; [
         nerd-fonts.hack
@@ -39,7 +39,6 @@
         pkgs.lazydocker
         pkgs.lazygit
         pkgs.neovim
-        pkgs.obsidian
         pkgs.ripgrep
         pkgs.starship
         pkgs.stow
@@ -55,6 +54,7 @@
           "brave-browser"
           "cryptomator"
           "firefox"
+          "obsidian"
           "openmtp"
           "raycast"
           "warp"
@@ -80,7 +80,7 @@
         finder.FXPreferredViewStyle = "clmv";
         screencapture.target = "file";
         screencapture.location = "~/Pictures/screenshots";
-        screensaver.askForPasswordDelay = 10;
+        screensaver.askForPasswordDelay = 0;
         loginwindow.LoginwindowText = "“Seja a mudança que você quer ver no mundo.“ – Mahatma Gandhi";
         loginwindow.GuestEnabled = false;
         menuExtraClock.Show24Hour = true;
@@ -169,7 +169,7 @@
         dock.persistent-apps = [
           "/Applications/Brave Browser.app"
           "/Applications/Warp.app"
-          "${pkgs.obsidian}/Applications/Obsidian.app"
+          "/Applications/Obsidian.app"
           "/Applications/qbittorrent.app"
           "/Applications/Telegram.app"
           "/Applications/WhatsApp.app"
@@ -227,6 +227,7 @@
           GuestEnabled = false;
           SHOWFULLNAME = false;
         };
+        screensaver.askForPasswordDelay = 10;
       };
       nixpkgs.hostPlatform = "aarch64-darwin";
     };

--- a/zsh/zsh-config.sh
+++ b/zsh/zsh-config.sh
@@ -3,7 +3,13 @@
 #TODO Testar se o arquivo ~/.zshrc existe e criar ele caso não exista e adicionar o comando ao final do arquivo `eval "$(starship init zsh)"`
 echo "Executando script criar o ~/.zshrc"
 if [[ ! -f ~/.zshrc ]]; then
-  stow . -v --adopt --target=$HOME
+  if [[ "${STOW_ADOPT:-0}" == "1" ]]; then
+    echo "Modo --adopt habilitado (STOW_ADOPT=1)."
+    stow . -v --adopt --target=$HOME
+  else
+    echo "Modo --adopt desabilitado. Defina STOW_ADOPT=1 para habilitar."
+    stow . -v --target=$HOME
+  fi
 else
   echo "Arquivo já existe e não precisa ser configurado."
 fi


### PR DESCRIPTION
### Motivation
- Evitar habilitar pacotes não-livres por padrão e instalar o Obsidian via Homebrew para não depender de `allowUnfree` no perfil Nix. 
- Garantir bloqueio imediato do sistema após o protetor de tela por padrão, com uma exceção para a máquina `Kyoshi`. 
- Fazer o uso de `stow --adopt` explícito e opt-in para evitar adoção acidental de arquivos quando não estiver configurando um usuário novo.

### Description
- Setei `nixpkgs.config.allowUnfree = false` em `nix/flake.nix` e removi `pkgs.obsidian` de `environment.systemPackages`, adicionando `"obsidian"` em `homebrew.casks` para instalação via Homebrew. 
- Ajustei `system.defaults.screensaver.askForPasswordDelay` para `0` no escopo comum e adicionei `screensaver.askForPasswordDelay = 10` na configuração `kyoshiConfiguration` como exceção. 
- Substituí referências de atalho do dock para o caminho de aplicação de Obsidian por `/Applications/Obsidian.app` onde aplicável. 
- Tornei o comportamento `stow --adopt` opt-in adicionando checagem de variável de ambiente `STOW_ADOPT` em `config.sh` e `zsh/zsh-config.sh`, com mensagens explicativas e fallback para `stow . -v` quando não habilitado. 

### Testing
- Nenhum teste automatizado foi executado para estas mudanças.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d0f053788321824d1733890738e8)